### PR TITLE
Changed some GTK styling for the window, slightly taller default and semi-translucency

### DIFF
--- a/fuzzy-windows
+++ b/fuzzy-windows
@@ -123,6 +123,9 @@ class FuzzyWindow(Gtk.Window):
         # Window is initially hidden
         self.hidden = True
 
+        # Set window opacity.
+        self.set_opacity(0.9)
+
         # Set up the vbox
         self.vbox = Gtk.Box(spacing=10)
         self.vbox.set_orientation(Gtk.Orientation.VERTICAL)
@@ -279,7 +282,7 @@ class Config:
             self.getOption('always_show_windows', [])
         )
         self.width = int(self.getOption('width', 700))
-        self.height = int(self.getOption('height', 200))
+        self.height = int(self.getOption('height', 300))
         self.ignored_window_types = self.getIgnoredWindowTypes()
 
     def getOption(self, option_name, default_value):


### PR DESCRIPTION
Hi, I thought it'd be good if you could see more open windows, so I made the switcher taller and changed the opacity so you can see the windows below the switcher.

![fuzzy-windows-opacity](https://cloud.githubusercontent.com/assets/54349/11218504/5c21785e-8d23-11e5-9c75-708675ae1190.png)
